### PR TITLE
Lock base version to current stable (3.6)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.6
 
 RUN apk update && apk upgrade \
   && apk add ca-certificates \


### PR DESCRIPTION
Commit 1945aee0 removed the version reference. This means that packaging changes can break things in the language specific images. I hit this when working with the Python images. Locking to the minor version avoids any surprises.