### PR TITLE
add common build tools to python dev images

### DIFF
--- a/python/python2/dev/Dockerfile
+++ b/python/python2/dev/Dockerfile
@@ -1,5 +1,4 @@
 FROM fnproject/python:2
 
-RUN apk add --no-cache curl python
-
+RUN apk add --no-cache curl git bash build-base linux-headers  python python2-dev py-setuptools  
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python

--- a/python/python3/dev/Dockerfile
+++ b/python/python3/dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM fnproject/python:3
 
-RUN apk add --no-cache curl python3 python3-dev build-base musl linux-headers
+RUN apk add --no-cache curl python3 python3-dev build-base linux-headers
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3

--- a/python/python3/dev/Dockerfile
+++ b/python/python3/dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM fnproject/python:3
 
-RUN apk add --no-cache curl python3
+RUN apk add --no-cache curl python3 python3-dev build-base musl linux-headers
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3

--- a/python/python3/dev/Dockerfile
+++ b/python/python3/dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM fnproject/python:3
 
-RUN apk add --no-cache curl python3 python3-dev build-base linux-headers
+RUN apk add --no-cache curl git bash python3 python3-dev build-base linux-headers
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3


### PR DESCRIPTION
can't build many dependencies without gcc and build tools 