### PR TITLE
Kotlin image fix

### DIFF
--- a/kotlin/dev/Dockerfile
+++ b/kotlin/dev/Dockerfile
@@ -1,8 +1,10 @@
 FROM fnproject/java:1.8
 
-ENV KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v1.0.5/kotlin-compiler-1.0.5.zip
+ENV KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v1.2.0/kotlin-compiler-1.2.0.zip
 
 RUN apk --no-cache add bash
+
+RUN apk add --update openssl
 
 RUN mkdir /opt
 


### PR DESCRIPTION
- fixed the SSL issue that was preventing fetching kotlinc from github
- switched to the latest kotlinc 1.2.0 (1.2 works fine on my CLI fork)
I haven't renamed build-broken.rb script