### PR TITLE
Dockerfiles for open source graalvm native-image.

### DIFF
--- a/svm/Dockerfile
+++ b/svm/Dockerfile
@@ -1,0 +1,7 @@
+FROM fnproject/fn-java-svm:dev as build
+
+FROM scratch as final
+LABEL maintainer="tomas.zezula@oracle.com"
+
+WORKDIR function
+ENTRYPOINT ["./func", "-XX:MaximumHeapSizePercent=80"]

--- a/svm/build.rb
+++ b/svm/build.rb
@@ -1,0 +1,34 @@
+
+require 'open3'
+require_relative '../utils/builder'
+
+name = "fnproject/fn-java-svm"
+
+Dir.chdir 'dev'
+tag = "dev"
+build("#{name}:#{tag}")
+v, status = Open3.capture2e("docker run --rm #{name}:#{tag} java -version")
+v = v.strip
+p v
+v = v.split( /\r?\n/ )
+p v
+v.each do |line|
+  puts "line: #{line}"
+  split = line.split(' ')
+  if split[1] == "version"
+    v = split[2]
+    break
+  end
+end
+v = v.tr('"', '')
+puts v
+split = v.split('_')
+v = split[0]
+puts v
+new_tags = vtag(name, tag, v, true, 1)
+
+Dir.chdir '..'
+tag = "latest"
+build("#{name}:#{tag}")
+puts v
+new_tags += vtag(name, tag, v, false, 1)

--- a/svm/dev/Dockerfile
+++ b/svm/dev/Dockerfile
@@ -1,0 +1,42 @@
+FROM openjdk:8-jdk-slim as build
+LABEL maintainer="tomas.zezula@oracle.com"
+
+RUN set -x \
+    && apt-get -y update \
+    && apt-get -y install gcc g++ git make openjdk-8-doc openjdk-8-source python zlib1g-dev
+
+ENV JVMCI_VERSION 0.46
+
+WORKDIR /build
+
+RUN set -x \
+    && git clone https://github.com/graalvm/mx.git \
+    && git clone https://github.com/graalvm/graal-jvmci-8.git \
+    && git -C graal-jvmci-8 checkout jvmci-${JVMCI_VERSION} \
+    && mx/mx --primary-suite graal-jvmci-8 --vm=server build -DFULL_DEBUG_SYMBOLS=0 \
+    && mx/mx --primary-suite graal-jvmci-8 --vm=server -v vm -version \
+    && mx/mx --primary-suite graal-jvmci-8 --vm=server -v unittest \
+    && cp -r $(/build/mx/mx --primary-suite graal-jvmci-8 jdkhome) /build/jvmcijdk8
+
+RUN git clone --branch release/graal-vm/1.0 https://github.com/oracle/graal.git
+WORKDIR /build/graal/vm
+RUN export JAVA_HOME=/build/jvmcijdk8 \
+    && /build/mx/mx --dy /substratevm --force-bash-launchers=true --disable-polyglot --disable-libpolyglot build
+
+WORKDIR /build/graal/vm/latest_graalvm
+RUN LONG_NAME=$(ls) \
+    && SHORT_NAME=graalvm \
+    && mv $LONG_NAME $SHORT_NAME
+
+FROM fnproject/fn-java-fdk-build:latest as final
+LABEL maintainer="tomas.zezula@oracle.com"
+
+RUN set -x \
+    && apt-get -y update \
+    && apt-get -y install gcc zlib1g-dev
+
+COPY --from=build /build/graal/vm/latest_graalvm/graalvm /usr/local/graalvm
+
+
+ENV GRAALVM_HOME=/usr/local/graalvm
+WORKDIR /function


### PR DESCRIPTION
This Pull Request provides `Dockerfile`s which can be used to create a native image from a Java application using the GraalVM `native-image` command.

The dev Docker image contains the `native-image` built from the open source GraalVM repository.
The runtime Docker image is based on `scratch`.